### PR TITLE
Define index mappings from collection metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Changelog
 - Add heartbeat (fixes #3)
 - Delete indices when buckets and collections are deleted (fixes #21)
 - Support quick search from querystring (fixes #34)
+- Support defining mapping from the ``index:schema`` property in the collection metadata (ref #8)
 
 **Bug fixes**
 

--- a/README.rst
+++ b/README.rst
@@ -126,6 +126,38 @@ Or an advanced search using request body:
     }
 
 
+Custom index mapping
+--------------------
+
+By default, ElasticSearch infers the data types from the indexed records.
+
+But it's possible to define the index mappings (ie. schema) from the collection metadata,
+in the ``index:schema`` property:
+
+.. code-block:: bash
+
+    $ echo '{
+      "data": {
+        "index:schema": {
+          "properties": {
+            "id": {"type": "keyword"},
+            "last_modified": {"type": "long"},
+            "build": {
+              "properties": {
+                  "date": {"type": "date", "format": "strict_date"},
+                  "id": {"type": "keyword"}
+              }
+            }
+          }
+        }
+      }
+    }' | http PATCH "http://localhost:8888/v1/buckets/blog/collections/builds" --auth token:admin-token --verbose
+
+Refer to ElasticSearch official documentation for more information about mappings.
+
+See also, `domapping <https://github.com/inveniosoftware/domapping/>`_ a CLI tool to convert JSON schemas to ElasticSearch mappings.
+
+
 Running the tests
 =================
 

--- a/kinto_elasticsearch/__init__.py
+++ b/kinto_elasticsearch/__init__.py
@@ -26,6 +26,8 @@ def includeme(config):
     config.add_subscriber(listener.on_server_flushed, ServerFlushed)
     config.add_subscriber(listener.on_collection_created, AfterResourceChanged,
                           for_resources=("collection",), for_actions=("create",))
+    config.add_subscriber(listener.on_collection_updated, AfterResourceChanged,
+                          for_resources=("collection",), for_actions=("update",))
     config.add_subscriber(listener.on_collection_deleted, AfterResourceChanged,
                           for_resources=("collection",), for_actions=("delete",))
     config.add_subscriber(listener.on_bucket_deleted, AfterResourceChanged,

--- a/kinto_elasticsearch/indexer.py
+++ b/kinto_elasticsearch/indexer.py
@@ -18,11 +18,15 @@ class Indexer(object):
     def indexname(self, bucket_id, collection_id):
         return "{}-{}-{}".format(self.prefix, bucket_id, collection_id)
 
-    def create_index(self, bucket_id, collection_id):
+    def create_index(self, bucket_id, collection_id, schema=None):
         indexname = self.indexname(bucket_id, collection_id)
         # Only if necessary.
         if not self.client.indices.exists(index=indexname):
-            self.client.indices.create(index=indexname)
+            if schema:
+                body = {"mappings": {indexname: schema}}
+            else:
+                body = None
+            self.client.indices.create(index=indexname, body=body)
 
     def delete_index(self, bucket_id, collection_id=None):
         if collection_id is None:

--- a/kinto_elasticsearch/indexer.py
+++ b/kinto_elasticsearch/indexer.py
@@ -27,6 +27,8 @@ class Indexer(object):
             else:
                 body = None
             self.client.indices.create(index=indexname, body=body)
+        else:
+            self.update_index(bucket_id, collection_id, schema)
 
     def update_index(self, bucket_id, collection_id, schema=None):
         indexname = self.indexname(bucket_id, collection_id)

--- a/kinto_elasticsearch/indexer.py
+++ b/kinto_elasticsearch/indexer.py
@@ -28,6 +28,14 @@ class Indexer(object):
                 body = None
             self.client.indices.create(index=indexname, body=body)
 
+    def update_index(self, bucket_id, collection_id, schema=None):
+        indexname = self.indexname(bucket_id, collection_id)
+        if schema is None:
+            schema = {"properties": {}}
+        self.client.indices.put_mapping(index=indexname,
+                                        doc_type=indexname,
+                                        body=schema)
+
     def delete_index(self, bucket_id, collection_id=None):
         if collection_id is None:
             collection_id = "*"

--- a/kinto_elasticsearch/listener.py
+++ b/kinto_elasticsearch/listener.py
@@ -12,7 +12,8 @@ def on_collection_created(event):
     bucket_id = event.payload["bucket_id"]
     for created in event.impacted_records:
         collection_id = created["new"]["id"]
-        indexer.create_index(bucket_id, collection_id)
+        schema = created["new"].get("index:schema")
+        indexer.create_index(bucket_id, collection_id, schema=schema)
 
 
 def on_collection_deleted(event):

--- a/kinto_elasticsearch/listener.py
+++ b/kinto_elasticsearch/listener.py
@@ -16,6 +16,20 @@ def on_collection_created(event):
         indexer.create_index(bucket_id, collection_id, schema=schema)
 
 
+def on_collection_updated(event):
+    indexer = event.request.registry.indexer
+    bucket_id = event.payload["bucket_id"]
+    for updated in event.impacted_records:
+        collection_id = updated["new"]["id"]
+        old_schema = updated["old"].get("index:schema")
+        new_schema = updated["new"].get("index:schema")
+        # Create if there was no index before.
+        if old_schema is None and new_schema is not None:
+            indexer.create_index(bucket_id, collection_id, schema=new_schema)
+        elif old_schema != new_schema:
+            indexer.update_index(bucket_id, collection_id, schema=new_schema)
+
+
 def on_collection_deleted(event):
     indexer = event.request.registry.indexer
     bucket_id = event.payload["bucket_id"]

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -193,7 +193,7 @@ class SchemaSupport(BaseWebTest, unittest.TestCase):
             "last_modified": {"type": "long"},
             "build": {
                 "properties": {
-                    "date": {"type": "date"},
+                    "date": {"type": "date", "format": "strict_date"},
                     "id": {"type": "keyword"}
                 }
             }
@@ -225,7 +225,7 @@ class SchemaSupport(BaseWebTest, unittest.TestCase):
                 "last_modified": {"type": "long"},
                 "build": {
                     "properties": {
-                        "date": {"type": "date"},
+                        "date": {"type": "date", "format": "strict_date"},
                         "id": {"type": "keyword"}
                     }
                 }

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -183,3 +183,89 @@ class PermissionsCheck(BaseWebTest, unittest.TestCase):
                            headers=headers)
 
         self.app.post("/buckets/bid/collections/cid/search", status=403, headers=headers)
+
+
+class SchemaSupport(BaseWebTest, unittest.TestCase):
+
+    schema = {
+        "properties": {
+            "id": {"type": "keyword"},
+            "last_modified": {"type": "long"},
+            "build": {
+                "properties": {
+                    "date": {"type": "date"},
+                    "id": {"type": "keyword"}
+                }
+            }
+        }
+    }
+
+    def setUp(self):
+        self.app.put("/buckets/bid", headers=self.headers)
+        body = {"data": {"index:schema": self.schema}}
+        self.app.put_json("/buckets/bid/collections/cid", body, headers=self.headers)
+        self.app.post_json("/buckets/bid/collections/cid/records",
+                           {"data": {"build": {"id": "abc", "date": "2017-05-24"}}},
+                           headers=self.headers)
+        self.app.post_json("/buckets/bid/collections/cid/records",
+                           {"data": {"build": {"id": "efg", "date": "2017-02-01"}}},
+                           headers=self.headers)
+
+    def get_mapping(self, bucket_id, collection_id):
+        indexer = self.app.app.registry.indexer
+        indexname = indexer.indexname(bucket_id, collection_id)
+        index_mapping = indexer.client.indices.get_mapping(indexname)
+        return index_mapping[indexname]["mappings"][indexname]
+
+    def test_index_has_mapping_if_collection_has_schema(self):
+        mapping = self.get_mapping("bid", "cid")
+        assert mapping == {
+            "properties": {
+                "id": {"type": "keyword"},
+                "last_modified": {"type": "long"},
+                "build": {
+                    "properties": {
+                        "date": {"type": "date"},
+                        "id": {"type": "keyword"}
+                    }
+                }
+            }
+        }
+
+    def test_can_search_for_subproperties(self):
+        body = {
+            "query": {
+                "bool" : {
+                    "must" : {
+                        "term" : { "build.id" : "abc" }
+                    }
+                }
+            }
+        }
+        resp = self.app.post_json("/buckets/bid/collections/cid/search", body,
+                                  headers=self.headers)
+        result = resp.json
+        assert len(result["hits"]["hits"]) == 1
+        assert result["hits"]["hits"][0]["_source"]["build"]["id"] == "abc"
+
+    def test_can_aggregate_values(self):
+        body = {
+          "aggs" : {
+            "build_dates" : {
+              "terms": {
+                "field" : "build.id",
+                "size" : 1000
+              }
+            }
+          }
+        }
+        resp = self.app.post_json("/buckets/bid/collections/cid/search", body,
+                                  headers=self.headers)
+        result = resp.json
+        assert result["aggregations"]["build_dates"]["buckets"] == [
+            {"key": "abc", "doc_count": 1},
+            {"key": "efg", "doc_count": 1},
+        ]
+
+    def test_mapping_is_updated_on_collection_update(self):
+        pass


### PR DESCRIPTION
Ref #8 

This is another approach to #36.

Since conversion from JSONSchema to ES mapping seems fragile. Let's take another curve and do something less smart but a lot simpler: read an explicit attribute `index:schema` in the collection metadata. 

@glasserc @n1k0 @Natim @magopian Thoughts?