### PR TITLE
Fix crash on search parse exceptions (fixes #44)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,8 @@ Changelog
 **Bug fixes**
 
 - Limit the number of results returned by default (fixes #45)
+- Fix crash on search parse exceptions (fixes #44)
+
 
 0.1.0 (2017-05-26)
 ------------------

--- a/kinto_elasticsearch/views.py
+++ b/kinto_elasticsearch/views.py
@@ -48,8 +48,12 @@ def search_view(request, **kwargs):
 
     except elasticsearch.RequestError as e:
         # Malformed query.
-        message = e.info["error"]["reason"]
-        details = e.info["error"]["root_cause"][0]
+        if isinstance(e.info["error"], dict):
+            message = e.info["error"]["reason"]
+            details = e.info["error"]["root_cause"][0]
+        else:
+            message = e.info["error"]
+            details = None
         response = http_error(httpexceptions.HTTPBadRequest(),
                               errno=ERRORS.INVALID_PARAMETERS,
                               message=message,

--- a/tests/test_elasticsearch.py
+++ b/tests/test_elasticsearch.py
@@ -384,3 +384,11 @@ class SchemaSupport(BaseWebTest, unittest.TestCase):
             {"key": "abc", "doc_count": 1},
             {"key": "efg", "doc_count": 1},
         ]
+
+    def test_search_parse_exception_returns_400(self):
+        e = elasticsearch.RequestError('', '',
+                                       {"error": "Could not find aggregator type"})
+        with mock.patch("kinto_elasticsearch.indexer.Indexer.search",
+                        side_effect=e):
+            self.app.post_json("/buckets/bid/collections/cid/search",
+                               headers=self.headers, status=400)


### PR DESCRIPTION
Fixes #44 

I couldn't reproduce what @n1k0 detected on the kinto-ota server, so I went with `mock`